### PR TITLE
Created a separate case in the cities reducer for fetchMoreCities

### DIFF
--- a/src/store/cities/actions.js
+++ b/src/store/cities/actions.js
@@ -5,11 +5,19 @@ import { selectToken } from "../user/selectors";
 
 export const FETCH_CITIES_SUCCESS = "FETCH_CITIES_SUCCESS";
 export const CREATE_CITY_SUCCES = "CREATE_CITY_SUCCES";
+export const FETCH_MORE_CITIES_SUCCES = "FETCH_MORE_CITIES_SUCCES";
 
 export const fetchCitiesSuccess = (cities) => {
   return {
     type: FETCH_CITIES_SUCCESS,
     payload: cities,
+  };
+};
+
+export const fetchMoreCitiesSuccess = (moreCities) => {
+  return {
+    type: FETCH_MORE_CITIES_SUCCES,
+    payload: moreCities,
   };
 };
 
@@ -45,8 +53,6 @@ export const fetchCities = () => {
 
 export const fetchMoreCities = () => {
   return async (dispatch, getState) => {
-    dispatch(appLoading());
-
     try {
       const offset = getState().cities.length;
 
@@ -61,7 +67,7 @@ export const fetchMoreCities = () => {
       // console.log("cities:", cities);
 
       // console.log("Fetch cities response:", response);
-      dispatch(fetchCitiesSuccess(cities));
+      dispatch(fetchMoreCitiesSuccess(cities));
       dispatch(appDoneLoading());
     } catch (error) {
       console.log("Error:", error);

--- a/src/store/cities/reducer.js
+++ b/src/store/cities/reducer.js
@@ -1,10 +1,17 @@
-import { FETCH_CITIES_SUCCESS, CREATE_CITY_SUCCES } from "./actions";
+import {
+  FETCH_CITIES_SUCCESS,
+  CREATE_CITY_SUCCES,
+  FETCH_MORE_CITIES_SUCCES,
+} from "./actions";
 
 const initialState = [];
 
 export default function cityReducer(state = initialState, action) {
   switch (action.type) {
     case FETCH_CITIES_SUCCESS:
+      return [...state, ...action.payload];
+
+    case FETCH_MORE_CITIES_SUCCES:
       return [...state, ...action.payload];
 
     case CREATE_CITY_SUCCES:


### PR DESCRIPTION
Created a separate case in the cities reducer for fetchMoreCities. 

Also tried to figure out why, when creating a new City Vibe, the new city + the 9 that were already there show up instead of 8. It's because the CREATE_NEW_CITY_SUCCES case is also returning the initialState, which are 9 cities. When creating a new city the page show's 10 cities instead of 9. It's not a big problem in my opinion, but I noticed it and wanted to fix it. No succes yet.